### PR TITLE
logic to determine if queueUrl was fully qualified was unclear, cleaned up

### DIFF
--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -409,23 +410,25 @@ func (s *SQS) query(queueUrl string, params map[string]string, resp interface{})
 	params["Version"] = "2011-10-01"
 	params["Timestamp"] = time.Now().In(time.UTC).Format(time.RFC3339)
 	var url_ *url.URL
-
 	var path string
-	if queueUrl != "" && len(queueUrl) > len(s.Region.SQSEndpoint) {
+
+	// fully qualified queueUrl
+	if strings.HasPrefix(queueUrl, "http") {
 		url_, err = url.Parse(queueUrl)
 		path = queueUrl[len(s.Region.SQSEndpoint):]
+		// non-qualified queueUrl
+	} else if strings.HasPrefix(queueUrl, "/") {
+		url_, err = url.Parse(s.Region.SQSEndpoint + queueUrl)
+		path = queueUrl
+		// everything else uses the SQSEndpoint by itself
 	} else {
 		url_, err = url.Parse(s.Region.SQSEndpoint)
 		path = "/"
 	}
+
 	if err != nil {
 		return err
 	}
-
-	//url_, err := url.Parse(s.Region.SQSEndpoint)
-	//if err != nil {
-	//	return err
-	//}
 
 	if s.Auth.Token() != "" {
 		params["SecurityToken"] = s.Auth.Token()


### PR DESCRIPTION
I was testing an internal SQS compatible service and noticed the logic to determine if a queue's URL was fully qualified seemed to be a little fragile.  This should make it clearer and handle cases where it is fully qualified or a relative URL.
