### PR TITLE
Adds TargetARN back to SNS Publish, fixes #15

### DIFF
--- a/exp/sns/subscription.go
+++ b/exp/sns/subscription.go
@@ -19,6 +19,7 @@ type PublishOpt struct {
 	MessageStructure string
 	Subject          string
 	TopicArn         string
+	TargetArn        string
 }
 
 type PublishResp struct {
@@ -77,6 +78,10 @@ func (sns *SNS) Publish(options *PublishOpt) (resp *PublishResp, err error) {
 
 	if options.TopicArn != "" {
 		params["TopicArn"] = options.TopicArn
+	}
+
+	if options.TargetArn != "" {
+		params["TargetArn"] = options.TargetArn
 	}
 
 	err = sns.query(params, resp)


### PR DESCRIPTION
Couldn't cherrypick 6c1f3072f5cd63b2c9a5ace6a2059130d4ed4740 from @maerlyn5 due to the refactor in #13, this adds the `TargetARN` functionality back in to SNS Publish fixing #15 
