### PR TITLE
Aws profile auth

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -374,6 +374,9 @@ func ProfileAuth() (auth Auth, err error) {
 	cfg := strings.Split(string(byteArray[:]), "\n")
 	found := false
 	for _, line := range cfg {
+		if line == "" {
+			continue
+		}
 		if found {
 			if string(line[0]) == "[" {
 				// Found the start of the next profile

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -18,9 +18,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"time"
-	"strings"
 	"runtime"
+	"strings"
+	"time"
 )
 
 // Defines the valid signers

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -91,3 +91,9 @@ func (s *S) TestRegionsAreNamed(c *gocheck.C) {
 		c.Assert(n, gocheck.Equals, r.Name)
 	}
 }
+
+func (s *S) TestProfileAuthNoProfile (c *gocheck.C) {
+	os.Clearenv()
+	_, err := aws.ProfileAuth()
+	c.Assert(err, gocheck.ErrorMatches, "AWS_PROFILE not found in the environment")
+}

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -92,7 +92,7 @@ func (s *S) TestRegionsAreNamed(c *gocheck.C) {
 	}
 }
 
-func (s *S) TestProfileAuthNoProfile (c *gocheck.C) {
+func (s *S) TestProfileAuthNoProfile(c *gocheck.C) {
 	os.Clearenv()
 	_, err := aws.ProfileAuth()
 	c.Assert(err, gocheck.ErrorMatches, "AWS_PROFILE not found in the environment")


### PR DESCRIPTION
See http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs

I noticed that there wasn't an option for authenticating with AWS using the Shared INI method, so I added one.  
This should also work on Windows (where the credentials file is located in %USERPROFILE%), but I don't have a machine to test this on.

I'm new to Go, so tell me if I've made any horrible (or tiny) mistakes.

I also did not know of a good way to test this, since it requires looking at a file outside of the project.