### PR TITLE
support AWS_SESSION_TOKEN if present in env

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -321,6 +321,7 @@ func GetAuth(accessKey string, secretKey, token string, expiration time.Time) (a
 // EnvAuth creates an Auth based on environment information.
 // The AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
 // variables are used.
+// AWS_SESSION_TOKEN is used if present.
 func EnvAuth() (auth Auth, err error) {
 	auth.AccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
 	if auth.AccessKey == "" {
@@ -337,6 +338,8 @@ func EnvAuth() (auth Auth, err error) {
 	if auth.SecretKey == "" {
 		err = errors.New("AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY not found in environment")
 	}
+
+	auth.token = os.Getenv("AWS_SESSION_TOKEN")
 	return
 }
 

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -1,12 +1,13 @@
 package aws_test
 
 import (
-	"github.com/goamz/goamz/aws"
-	"github.com/motain/gocheck"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/goamz/goamz/aws"
+	"github.com/motain/gocheck"
 )
 
 func Test(t *testing.T) {
@@ -60,6 +61,18 @@ func (s *S) TestEnvAuthAlt(c *gocheck.C) {
 	auth, err := aws.EnvAuth()
 	c.Assert(err, gocheck.IsNil)
 	c.Assert(auth, gocheck.Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})
+}
+
+func (s *S) TestEnvAuthToken(c *gocheck.C) {
+	os.Clearenv()
+	os.Setenv("AWS_SECRET_KEY", "secret")
+	os.Setenv("AWS_ACCESS_KEY", "access")
+	os.Setenv("AWS_SESSION_TOKEN", "token")
+	auth, err := aws.EnvAuth()
+	c.Assert(err, gocheck.IsNil)
+	c.Assert(auth.SecretKey, gocheck.Equals, "secret")
+	c.Assert(auth.AccessKey, gocheck.Equals, "access")
+	c.Assert(auth.Token(), gocheck.Equals, "token")
 }
 
 func (s *S) TestGetAuthStatic(c *gocheck.C) {


### PR DESCRIPTION
We take advantage of [AWS MFA](http://aws.amazon.com/iam/details/mfa/), and pass a [standard](http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs) `AWS_SESSION_TOKEN` env var to our tooling.

By adding this, our tooling that leans on `goamz` becomes MFA-enabled.

Thank you!
