### PR TITLE
remove unnecessary fmt.Println(err) from EC2 DescribeInstanceStatus meth...

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -708,7 +708,6 @@ func (ec2 *EC2) DescribeInstanceStatus(options *DescribeInstanceStatusOptions, f
 	resp = &DescribeInstanceStatusResp{}
 	err = ec2.query(params, resp)
 	if err != nil {
-		fmt.Println(err)
 		return nil, err
 	}
 	return


### PR DESCRIPTION
DescribeInstanceStatus always print err if it fails 
