### PR TITLE
Update travis to build against additional versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.2
   - 1.3
   - 1.4
+  - tip
 
 before_script:
   - FIXED=$(go fmt ./... | wc -l); if [ $FIXED -gt 0 ]; then echo "gofmt - $FIXED file(s) not formatted correctly, please run gofmt to fix this." && exit 1; fi


### PR DESCRIPTION
#55 removed `1.2` and we were missing `1.3`. We should probably also test against `tip`.
