### PR TITLE
HTTP response 206(Partial Content)

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -1013,7 +1013,7 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 		dump, _ := httputil.DumpResponse(hresp, true)
 		log.Printf("} -> %s\n", dump)
 	}
-	if hresp.StatusCode != 200 && hresp.StatusCode != 204 {
+	if hresp.StatusCode != 200 && hresp.StatusCode != 204 && hresp.StatusCode != 206 {
 		defer hresp.Body.Close()
 		return nil, buildError(hresp)
 	}


### PR DESCRIPTION
when using `Range: bytes=xxxx-xxxx` header to [S3 GET Object](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html), S3 returns response with `206 Partial Content`.
so S3.run() should allow status code 206.