### PR TITLE
Added Queue.SendMessageWithAttributes to SQS

### DIFF
--- a/sqs/responses_test.go
+++ b/sqs/responses_test.go
@@ -43,6 +43,7 @@ var TestSendMessageXmlOK = `
   <SendMessageResult>
     <MD5OfMessageBody>fafb00f5732ab283681e124bf8747ed1</MD5OfMessageBody>
     <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+    <MD5OfMessageAttributes>ba056227cfd9533dba1f72ad9816d233</MD5OfMessageAttributes>
   </SendMessageResult>
   <ResponseMetadata>
     <RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId>

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -13,7 +13,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/goamz/goamz/aws"
 	"io"
 	"io/ioutil"
 	"log"
@@ -23,6 +22,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/goamz/goamz/aws"
 )
 
 const API_VERSION = "2012-11-05"
@@ -301,24 +302,24 @@ func (q *Queue) SendMessage(MessageBody string) (resp *SendMessageResponse, err 
 }
 
 func (q *Queue) SendMessageWithAttributes(MessageBody string, attrs map[string]string) (resp *SendMessageResponse, err error) {
-        resp = &SendMessageResponse{}
-        params := makeParams("SendMessage")
+	resp = &SendMessageResponse{}
+	params := makeParams("SendMessage")
 
-        params["MessageBody"] = MessageBody
+	params["MessageBody"] = MessageBody
 
-        i := 1
-        for k, v := range attrs {
-                nameParam := fmt.Sprintf("MessageAttribute.%d.Name", i)
-                valParam := fmt.Sprintf("MessageAttribute.%d.Value.StringValue", i)
-                typeParam := fmt.Sprintf("MessageAttribute.%d.Value.DataType", i)
-                params[nameParam] = k
-                params[valParam] = v
-                params[typeParam] = "String"
-                i++
-        }
+	i := 1
+	for k, v := range attrs {
+		nameParam := fmt.Sprintf("MessageAttribute.%d.Name", i)
+		valParam := fmt.Sprintf("MessageAttribute.%d.Value.StringValue", i)
+		typeParam := fmt.Sprintf("MessageAttribute.%d.Value.DataType", i)
+		params[nameParam] = k
+		params[valParam] = v
+		params[typeParam] = "String"
+		i++
+	}
 
-        err = q.SQS.query(q.Url, params, resp)
-        return
+	err = q.SQS.query(q.Url, params, resp)
+	return
 }
 
 // ReceiveMessageWithVisibilityTimeout

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -110,9 +110,10 @@ type PurgeQueueResponse struct {
 }
 
 type SendMessageResponse struct {
-	MD5              string `xml:"SendMessageResult>MD5OfMessageBody"`
-	Id               string `xml:"SendMessageResult>MessageId"`
-	ResponseMetadata ResponseMetadata
+	MD5                    string `xml:"SendMessageResult>MD5OfMessageBody"`
+	MD5OfMessageAttributes string `xml:"SendMessageResult>MD5OfMessageAttributes"`
+	Id                     string `xml:"SendMessageResult>MessageId"`
+	ResponseMetadata       ResponseMetadata
 }
 
 type ReceiveMessageResponse struct {

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -300,6 +300,27 @@ func (q *Queue) SendMessage(MessageBody string) (resp *SendMessageResponse, err 
 	return
 }
 
+func (q *Queue) SendMessageWithAttributes(MessageBody string, attrs map[string]string) (resp *SendMessageResponse, err error) {
+        resp = &SendMessageResponse{}
+        params := makeParams("SendMessage")
+
+        params["MessageBody"] = MessageBody
+
+        i := 1
+        for k, v := range attrs {
+                nameParam := fmt.Sprintf("MessageAttribute.%d.Name", i)
+                valParam := fmt.Sprintf("MessageAttribute.%d.Value.StringValue", i)
+                typeParam := fmt.Sprintf("MessageAttribute.%d.Value.DataType", i)
+                params[nameParam] = k
+                params[valParam] = v
+                params[typeParam] = "String"
+                i++
+        }
+
+        err = q.SQS.query(q.Url, params, resp)
+        return
+}
+
 // ReceiveMessageWithVisibilityTimeout
 func (q *Queue) ReceiveMessageWithVisibilityTimeout(MaxNumberOfMessages, VisibilityTimeoutSec int) (*ReceiveMessageResponse, error) {
 	params := map[string]string{

--- a/sqs/sqs_test.go
+++ b/sqs/sqs_test.go
@@ -2,6 +2,7 @@ package sqs
 
 import (
 	"crypto/md5"
+	"encoding/binary"
 	"fmt"
 	"hash"
 
@@ -163,6 +164,43 @@ func (s *S) TestSendMessageRelativePath(c *C) {
 	c.Assert(resp.MD5, Equals, fmt.Sprintf("%x", h.Sum(nil)))
 	c.Assert(resp.Id, Equals, "5fea7756-0ea4-451a-a703-a558b933e274")
 	c.Assert(err, IsNil)
+}
+
+func encodeMessageAttribute(str string) []byte {
+	bstr := []byte(str)
+	bs := make([]byte, 4+len(bstr))
+	binary.BigEndian.PutUint32(bs, uint32(len(bstr)))
+	copy(bs[4:len(bs)], bstr)
+	return bs
+}
+
+func (s *S) TestSendMessageWithAttributes(c *gocheck.C) {
+	testServer.PrepareResponse(200, nil, TestSendMessageXmlOK)
+
+	q := &Queue{s.sqs, testServer.URL + "/123456789012/testQueue/"}
+	attrs := map[string]string{
+		"test_attribute_name_1": "test_attribute_value_1",
+	}
+	resp, err := q.SendMessageWithAttributes("This is a test message", attrs)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Method, gocheck.Equals, "GET")
+	c.Assert(req.URL.Path, gocheck.Equals, "/123456789012/testQueue/")
+	c.Assert(req.Header["Date"], gocheck.Not(gocheck.Equals), "")
+
+	var attrsHash = md5.New()
+	attrsHash.Write(encodeMessageAttribute("test_attribute_name_1"))
+	attrsHash.Write(encodeMessageAttribute("String"))
+	attrsHash.Write([]byte{1})
+	attrsHash.Write(encodeMessageAttribute("test_attribute_value_1"))
+	c.Assert(resp.MD5OfMessageAttributes, gocheck.Equals, fmt.Sprintf("%x", attrsHash.Sum(nil)))
+
+	msg := "This is a test message"
+	var h hash.Hash = md5.New()
+	h.Write([]byte(msg))
+	c.Assert(resp.MD5, gocheck.Equals, fmt.Sprintf("%x", h.Sum(nil)))
+	c.Assert(resp.Id, gocheck.Equals, "5fea7756-0ea4-451a-a703-a558b933e274")
+	c.Assert(err, gocheck.IsNil)
 }
 
 func (s *S) TestSendMessageBatch(c *C) {

--- a/sqs/sqs_test.go
+++ b/sqs/sqs_test.go
@@ -174,7 +174,7 @@ func encodeMessageAttribute(str string) []byte {
 	return bs
 }
 
-func (s *S) TestSendMessageWithAttributes(c *gocheck.C) {
+func (s *S) TestSendMessageWithAttributes(c *C) {
 	testServer.PrepareResponse(200, nil, TestSendMessageXmlOK)
 
 	q := &Queue{s.sqs, testServer.URL + "/123456789012/testQueue/"}
@@ -184,23 +184,23 @@ func (s *S) TestSendMessageWithAttributes(c *gocheck.C) {
 	resp, err := q.SendMessageWithAttributes("This is a test message", attrs)
 	req := testServer.WaitRequest()
 
-	c.Assert(req.Method, gocheck.Equals, "GET")
-	c.Assert(req.URL.Path, gocheck.Equals, "/123456789012/testQueue/")
-	c.Assert(req.Header["Date"], gocheck.Not(gocheck.Equals), "")
+	c.Assert(req.Method, Equals, "GET")
+	c.Assert(req.URL.Path, Equals, "/123456789012/testQueue/")
+	c.Assert(req.Header["Date"], Not(Equals), "")
 
 	var attrsHash = md5.New()
 	attrsHash.Write(encodeMessageAttribute("test_attribute_name_1"))
 	attrsHash.Write(encodeMessageAttribute("String"))
 	attrsHash.Write([]byte{1})
 	attrsHash.Write(encodeMessageAttribute("test_attribute_value_1"))
-	c.Assert(resp.MD5OfMessageAttributes, gocheck.Equals, fmt.Sprintf("%x", attrsHash.Sum(nil)))
+	c.Assert(resp.MD5OfMessageAttributes, Equals, fmt.Sprintf("%x", attrsHash.Sum(nil)))
 
 	msg := "This is a test message"
 	var h hash.Hash = md5.New()
 	h.Write([]byte(msg))
-	c.Assert(resp.MD5, gocheck.Equals, fmt.Sprintf("%x", h.Sum(nil)))
-	c.Assert(resp.Id, gocheck.Equals, "5fea7756-0ea4-451a-a703-a558b933e274")
-	c.Assert(err, gocheck.IsNil)
+	c.Assert(resp.MD5, Equals, fmt.Sprintf("%x", h.Sum(nil)))
+	c.Assert(resp.Id, Equals, "5fea7756-0ea4-451a-a703-a558b933e274")
+	c.Assert(err, IsNil)
 }
 
 func (s *S) TestSendMessageBatch(c *C) {


### PR DESCRIPTION
Added Queue.SendMessageWithAttributes to SQS, attributes can only be string for now.

I tested it against the real API and it works.

Let me know if I need to change something in order to get this feature merged.

Thanks!