### PR TITLE
More consistent pointer usage + refactor of DeleteMessageBatch

### DIFF
--- a/sqs/sqs_test.go
+++ b/sqs/sqs_test.go
@@ -229,8 +229,8 @@ func (s *S) TestDeleteMessageBatch(c *C) {
 
 	q := &Queue{s.sqs, testServer.URL + "/123456789012/testQueue/"}
 
-	msgList := []Message{*(&Message{ReceiptHandle: "gfk0T0R0waama4fVFffkjPQrrvzMrOg0fTFk2LxT33EuB8wR0ZCFgKWyXGWFoqqpCIiprQUEhir%2F5LeGPpYTLzjqLQxyQYaQALeSNHb0us3uE84uujxpBhsDkZUQkjFFkNqBXn48xlMcVhTcI3YLH%2Bd%2BIqetIOHgBCZAPx6r%2B09dWaBXei6nbK5Ygih21DCDdAwFV68Jo8DXhb3ErEfoDqx7vyvC5nCpdwqv%2BJhU%2FTNGjNN8t51v5c%2FAXvQsAzyZVNapxUrHIt4NxRhKJ72uICcxruyE8eRXlxIVNgeNP8ZEDcw7zZU1Zw%3D%3D"}),
-		*(&Message{ReceiptHandle: "gfk0T0R0waama4fVFffkjKzmhMCymjQvfTFk2LxT33G4ms5subrE0deLKWSscPU1oD3J9zgeS4PQQ3U30qOumIE6AdAv3w%2F%2Fa1IXW6AqaWhGsEPaLm3Vf6IiWqdM8u5imB%2BNTwj3tQRzOWdTOePjOjPcTpRxBtXix%2BEvwJOZUma9wabv%2BSw6ZHjwmNcVDx8dZXJhVp16Bksiox%2FGrUvrVTCJRTWTLc59oHLLF8sEkKzRmGNzTDGTiV%2BYjHfQj60FD3rVaXmzTsoNxRhKJ72uIHVMGVQiAGgB%2BqAbSqfKHDQtVOmJJgkHug%3D%3D"}),
+	msgList := []*Message{&Message{ReceiptHandle: "gfk0T0R0waama4fVFffkjPQrrvzMrOg0fTFk2LxT33EuB8wR0ZCFgKWyXGWFoqqpCIiprQUEhir%2F5LeGPpYTLzjqLQxyQYaQALeSNHb0us3uE84uujxpBhsDkZUQkjFFkNqBXn48xlMcVhTcI3YLH%2Bd%2BIqetIOHgBCZAPx6r%2B09dWaBXei6nbK5Ygih21DCDdAwFV68Jo8DXhb3ErEfoDqx7vyvC5nCpdwqv%2BJhU%2FTNGjNN8t51v5c%2FAXvQsAzyZVNapxUrHIt4NxRhKJ72uICcxruyE8eRXlxIVNgeNP8ZEDcw7zZU1Zw%3D%3D"},
+		&Message{ReceiptHandle: "gfk0T0R0waama4fVFffkjKzmhMCymjQvfTFk2LxT33G4ms5subrE0deLKWSscPU1oD3J9zgeS4PQQ3U30qOumIE6AdAv3w%2F%2Fa1IXW6AqaWhGsEPaLm3Vf6IiWqdM8u5imB%2BNTwj3tQRzOWdTOePjOjPcTpRxBtXix%2BEvwJOZUma9wabv%2BSw6ZHjwmNcVDx8dZXJhVp16Bksiox%2FGrUvrVTCJRTWTLc59oHLLF8sEkKzRmGNzTDGTiV%2BYjHfQj60FD3rVaXmzTsoNxRhKJ72uIHVMGVQiAGgB%2BqAbSqfKHDQtVOmJJgkHug%3D%3D"},
 	}
 
 	resp, err := q.DeleteMessageBatch(msgList)
@@ -364,7 +364,7 @@ func (s *S) TestChangeMessageVisibility(c *C) {
 
 	testServer.PrepareResponse(200, nil, TestChangeMessageVisibilityXmlOK)
 
-	resp, err := q.ChangeMessageVisibility(&resp1.Messages[0], 50)
+	resp, err := q.ChangeMessageVisibility(resp1.Messages[0], 50)
 	req = testServer.WaitRequest()
 
 	c.Assert(req.Method, Equals, "GET")


### PR DESCRIPTION
This PR fixes #62 and refactors `DeleteMessageBatch`, introducing the following changes:

- `ReceiveMessageResponse` has a `[]*Message` instead of a slice of values as `Messages` are large enough that they'll usually be passed by pointer instead of by value, and methods like `DeleteMessage` already worked with pointers
- `(Send|Delete)MessageBatch` changed to take `[]*Message` instead of `[]Message`
- type `Error`'s `Error() string` changed to a value receiver instead of a pointer receiver as it's a small-ish type and `xmlErrors` already contained values instead of pointers
- refactored `DeleteMessageBatch` so it doesn't allocate a map and a slice just to output a log message (should I make a separate PR for this?)

Some of the changes aren't backwards-compatible.