### PR TITLE
Added SharedAuth method, from mitchellh/goamz

### DIFF
--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -1,6 +1,7 @@
 package aws_test
 
 import (
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -30,6 +31,110 @@ func (s *S) TearDownTest(c *C) {
 		l := strings.SplitN(kv, "=", 2)
 		os.Setenv(l[0], l[1])
 	}
+}
+
+func (s *S) TestSharedAuthNoHome(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "foo")
+	_, err := aws.SharedAuth()
+	c.Assert(err, ErrorMatches, "Could not get HOME")
+}
+
+func (s *S) TestSharedAuthNoCredentialsFile(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "foo")
+	os.Setenv("HOME", "/tmp")
+	_, err := aws.SharedAuth()
+	c.Assert(err, ErrorMatches, "Couldn't parse AWS credentials file")
+}
+
+func (s *S) TestSharedAuthNoProfileInFile(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "foo")
+
+	d, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(d)
+
+	err = os.Mkdir(d+"/.aws", 0755)
+	if err != nil {
+		panic(err)
+	}
+
+	ioutil.WriteFile(d+"/.aws/credentials", []byte("[bar]\n"), 0644)
+	os.Setenv("HOME", d)
+
+	_, err = aws.SharedAuth()
+	c.Assert(err, ErrorMatches, "Couldn't find profile in AWS credentials file")
+}
+
+func (s *S) TestSharedAuthNoKeysInProfile(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "bar")
+
+	d, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(d)
+
+	err = os.Mkdir(d+"/.aws", 0755)
+	if err != nil {
+		panic(err)
+	}
+
+	ioutil.WriteFile(d+"/.aws/credentials", []byte("[bar]\nawsaccesskeyid = AK.."), 0644)
+	os.Setenv("HOME", d)
+
+	_, err = aws.SharedAuth()
+	c.Assert(err, ErrorMatches, "AWS_SECRET_ACCESS_KEY not found in credentials file")
+}
+
+func (s *S) TestSharedAuthDefaultCredentials(c *C) {
+	os.Clearenv()
+
+	d, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(d)
+
+	err = os.Mkdir(d+"/.aws", 0755)
+	if err != nil {
+		panic(err)
+	}
+
+	ioutil.WriteFile(d+"/.aws/credentials", []byte("[default]\naws_access_key_id = access\naws_secret_access_key = secret\n"), 0644)
+	os.Setenv("HOME", d)
+
+	auth, err := aws.SharedAuth()
+	c.Assert(err, IsNil)
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})
+}
+
+func (s *S) TestSharedAuth(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "bar")
+
+	d, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(d)
+
+	err = os.Mkdir(d+"/.aws", 0755)
+	if err != nil {
+		panic(err)
+	}
+
+	ioutil.WriteFile(d+"/.aws/credentials", []byte("[bar]\naws_access_key_id = access\naws_secret_access_key = secret\n"), 0644)
+	os.Setenv("HOME", d)
+
+	auth, err := aws.SharedAuth()
+	c.Assert(err, IsNil)
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})
 }
 
 func (s *S) TestEnvAuthNoSecret(c *C) {


### PR DESCRIPTION
Originally added to mitchellh/goamz by https://github.com/mitchellh/goamz/commit/19bd918f6ca130fe1fa7e9860df35b8b84f8a2d4 (and since updated slightly).

Wording from that commit: "Most AWS SDKs now support the use of shared profiles in
~/.aws/credentials. The AWS_PROFILE environment variable is then used to
pick the profile to be used."

Adds a dependency on vaughan0/go-ini 

This is just a copy/paste by me (o172) as I need this feature, and I'm using goamz/goamz for cloudformation support.