### PR TITLE
adding support for egress rules

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -1786,6 +1786,14 @@ func (ec2 *EC2) RevokeSecurityGroup(group SecurityGroup, perms []IPPerm) (resp *
 	return ec2.authOrRevoke("RevokeSecurityGroupIngress", group, perms)
 }
 
+// AuthorizeSecurityGroupEgress creates an allowance for instances within the
+// given security group to access servers matching the provided rules.
+//
+// See http://goo.gl/R91LXY for more details.
+func (ec2 *EC2) AuthorizeSecurityGroupEgress(group SecurityGroup, perms []IPPerm) (resp *SimpleResp, err error) {
+	return ec2.authOrRevoke("AuthorizeSecurityGroupEgress", group, perms)
+}
+
 // RevokeSecurityGroupEgress revokes egress permissions from a group
 //
 // see http://goo.gl/Zv4wh8

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -15,7 +15,6 @@ import (
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
-	"github.com/goamz/goamz/aws"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -24,6 +23,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/goamz/goamz/aws"
 )
 
 const debug = false
@@ -1669,9 +1670,10 @@ type SecurityGroupsResp struct {
 // See http://goo.gl/CIdyP for more details.
 type SecurityGroupInfo struct {
 	SecurityGroup
-	OwnerId     string   `xml:"ownerId"`
-	Description string   `xml:"groupDescription"`
-	IPPerms     []IPPerm `xml:"ipPermissions>item"`
+	OwnerId       string   `xml:"ownerId"`
+	Description   string   `xml:"groupDescription"`
+	IPPerms       []IPPerm `xml:"ipPermissions>item"`
+	IPPermsEgress []IPPerm `xml:"ipPermissionsEgress>item"`
 }
 
 // IPPerm represents an allowance within an EC2 security group.
@@ -1782,6 +1784,13 @@ func (ec2 *EC2) AuthorizeSecurityGroup(group SecurityGroup, perms []IPPerm) (res
 // See http://goo.gl/ZgdxA for more details.
 func (ec2 *EC2) RevokeSecurityGroup(group SecurityGroup, perms []IPPerm) (resp *SimpleResp, err error) {
 	return ec2.authOrRevoke("RevokeSecurityGroupIngress", group, perms)
+}
+
+// RevokeSecurityGroupEgress revokes egress permissions from a group
+//
+// see http://goo.gl/Zv4wh8
+func (ec2 *EC2) RevokeSecurityGroupEgress(group SecurityGroup, perms []IPPerm) (resp *SimpleResp, err error) {
+	return ec2.authOrRevoke("RevokeSecurityGroupEgress", group, perms)
 }
 
 func (ec2 *EC2) authOrRevoke(op string, group SecurityGroup, perms []IPPerm) (resp *SimpleResp, err error) {

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -725,12 +725,19 @@ func (s *S) TestDescribeSecurityGroupsExample(c *C) {
 	c.Assert(g0.Id, Equals, "sg-67ad940e")
 	c.Assert(g0.Description, Equals, "Web Servers")
 	c.Assert(g0.IPPerms, HasLen, 1)
+	c.Assert(g0.IPPermsEgress, HasLen, 1)
 
 	g0ipp := g0.IPPerms[0]
 	c.Assert(g0ipp.Protocol, Equals, "tcp")
 	c.Assert(g0ipp.FromPort, Equals, 80)
 	c.Assert(g0ipp.ToPort, Equals, 80)
 	c.Assert(g0ipp.SourceIPs, DeepEquals, []string{"0.0.0.0/0"})
+
+	g0ippe := g0.IPPermsEgress[0]
+	c.Assert(g0ippe.Protocol, Equals, "tcp")
+	c.Assert(g0ippe.FromPort, Equals, 80)
+	c.Assert(g0ippe.ToPort, Equals, 80)
+	c.Assert(g0ippe.SourceIPs, DeepEquals, []string{"0.0.0.0/0"})
 
 	g1 := resp.Groups[1]
 	c.Assert(g1.OwnerId, Equals, "999988887777")

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -662,6 +662,19 @@ var DescribeSecurityGroupsExample = `
            </ipRanges>
         </item>
       </ipPermissions>
+      <ipPermissionsEgress>
+        <item>
+          <ipProtocol>tcp</ipProtocol>
+          <fromPort>80</fromPort>
+          <toPort>80</toPort>
+          <groups/>
+          <ipRanges>
+             <item>
+               <cidrIp>0.0.0.0/0</cidrIp>
+             </item>
+            </ipRanges>
+          </item>
+        </ipPermissionsEgress>
     </item>
     <item>
       <ownerId>999988887777</ownerId>
@@ -906,7 +919,7 @@ var ReplaceRouteTableAssociationExample = `
 `
 var DescribeReservedInstancesExample = `
 <DescribeReservedInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <reservedInstancesSet>
       <item>
          <reservedInstancesId>e5a2ff3b-7d14-494f-90af-0b5d0EXAMPLE</reservedInstancesId>
@@ -917,12 +930,12 @@ var DescribeReservedInstancesExample = `
          <usagePrice>0.034</usagePrice>
          <instanceCount>3</instanceCount>
          <productDescription>Linux/UNIX</productDescription>
-         <state>active</state> 
+         <state>active</state>
          <instanceTenancy>default</instanceTenancy>
          <currencyCode>USD</currencyCode>
          <offeringType>Light Utilization</offeringType>
          <recurringCharges/>
       </item>
-   </reservedInstancesSet> 
+   </reservedInstancesSet>
 </DescribeReservedInstancesResponse>
 `


### PR DESCRIPTION
AuthorizeSecurityGroup and RevokeSecurityGroup should probably be renamed to include Ingress to match the API but are left for backwards compatibility.

I could add the correctly named functions and just call them from the existing functions. Thoughts?