### PR TITLE
Bug/global sec idx

### DIFF
--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"encoding/json"
+	"log"
 	"sort"
 )
 
@@ -132,8 +133,33 @@ func (q *Query) AddCreateRequestTable(description TableDescriptionT) {
 		})
 	}
 
+	globalSecondaryIndexes := []interface{}{}
+	intmax := func(x, y int64) int64 {
+		if x > y {
+			return x
+		}
+		return y
+	}
+	for _, ind := range description.GlobalSecondaryIndexes {
+		rec := msi{
+			"IndexName":  ind.IndexName,
+			"KeySchema":  ind.KeySchema,
+			"Projection": ind.Projection,
+		}
+		// need at least one unit, and since go's max() is float based.
+		rec["ProvisionedThroughput"] = msi{
+			"ReadCapacityUnits":  intmax(1, ind.ProvisionedThroughput.ReadCapacityUnits),
+			"WriteCapacityUnits": intmax(1, ind.ProvisionedThroughput.WriteCapacityUnits),
+		}
+		globalSecondaryIndexes = append(globalSecondaryIndexes, rec)
+	}
+
 	if len(localSecondaryIndexes) > 0 {
 		b["LocalSecondaryIndexes"] = localSecondaryIndexes
+	}
+
+	if len(globalSecondaryIndexes) > 0 {
+		b["GlobalSecondaryIndexes"] = globalSecondaryIndexes
 	}
 }
 

--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -2,7 +2,6 @@ package dynamodb
 
 import (
 	"encoding/json"
-	"log"
 	"sort"
 )
 

--- a/dynamodb/table.go
+++ b/dynamodb/table.go
@@ -27,6 +27,15 @@ type ProjectionT struct {
 	ProjectionType string
 }
 
+type GlobalSecondaryIndexT struct {
+	IndexName             string
+	IndexSizeBytes        int64
+	ItemCount             int64
+	KeySchema             []KeySchemaT
+	Projection            ProjectionT
+	ProvisionedThroughput ProvisionedThroughputT
+}
+
 type LocalSecondaryIndexT struct {
 	IndexName      string
 	IndexSizeBytes int64
@@ -42,15 +51,16 @@ type ProvisionedThroughputT struct {
 }
 
 type TableDescriptionT struct {
-	AttributeDefinitions  []AttributeDefinitionT
-	CreationDateTime      float64
-	ItemCount             int64
-	KeySchema             []KeySchemaT
-	LocalSecondaryIndexes []LocalSecondaryIndexT
-	ProvisionedThroughput ProvisionedThroughputT
-	TableName             string
-	TableSizeBytes        int64
-	TableStatus           string
+	AttributeDefinitions   []AttributeDefinitionT
+	CreationDateTime       float64
+	ItemCount              int64
+	KeySchema              []KeySchemaT
+	GlobalSecondaryIndexes []GlobalSecondaryIndexT
+	LocalSecondaryIndexes  []LocalSecondaryIndexT
+	ProvisionedThroughput  ProvisionedThroughputT
+	TableName              string
+	TableSizeBytes         int64
+	TableStatus            string
 }
 
 type describeTableResponse struct {

--- a/dynamodb/table_test.go
+++ b/dynamodb/table_test.go
@@ -30,10 +30,25 @@ var table_suite = &TableSuite{
 		AttributeDefinitions: []dynamodb.AttributeDefinitionT{
 			dynamodb.AttributeDefinitionT{"TestHashKey", "S"},
 			dynamodb.AttributeDefinitionT{"TestRangeKey", "N"},
+			dynamodb.AttributeDefinitionT{"TestSecKey", "N"},
 		},
 		KeySchema: []dynamodb.KeySchemaT{
 			dynamodb.KeySchemaT{"TestHashKey", "HASH"},
 			dynamodb.KeySchemaT{"TestRangeKey", "RANGE"},
+		},
+		GlobalSecondaryIndexes: []dynamodb.GlobalSecondaryIndexT{
+			dynamodb.GlobalSecondaryIndexT{
+				IndexName: "gsiTest",
+				KeySchema: []dynamodb.KeySchemaT{
+					dynamodb.KeySchemaT{"TestHashKey", "HASH"},
+					dynamodb.KeySchemaT{"TestSecKey", "RANGE"},
+				},
+				Projection: dynamodb.ProjectionT{"ALL"},
+				ProvisionedThroughput: dynamodb.ProvisionedThroughputT{
+					ReadCapacityUnits:  1,
+					WriteCapacityUnits: 1,
+				},
+			},
 		},
 		ProvisionedThroughput: dynamodb.ProvisionedThroughputT{
 			ReadCapacityUnits:  1,


### PR DESCRIPTION
DynamoDB allows global secondary indexes so that data can be searched in more than one way. We're using a secondary index as part of a garbage collection process, so we added the code.

resolves issue #66 