### PR TITLE
fix keep alive for s3

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -18,7 +18,6 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
-	"github.com/goamz/goamz/aws"
 	"io"
 	"io/ioutil"
 	"log"
@@ -29,6 +28,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/goamz/goamz/aws"
 )
 
 const debug = false
@@ -278,7 +279,18 @@ func (b *Bucket) Exists(path string) (exists bool, err error) {
 		resp, err := b.S3.run(req, nil)
 
 		if shouldRetry(err) && attempt.HasNext() {
+			if resp != nil && resp.Body != nil {
+				io.Copy(ioutil.Discard, resp.Body)
+				resp.Body.Close()
+			}
 			continue
+		}
+
+		if resp != nil && resp.Body != nil {
+			defer func() {
+				io.Copy(ioutil.Discard, resp.Body)
+				resp.Body.Close()
+			}()
 		}
 
 		if err != nil {
@@ -292,6 +304,7 @@ func (b *Bucket) Exists(path string) (exists bool, err error) {
 		if resp.StatusCode/100 == 2 {
 			exists = true
 		}
+
 		return exists, err
 	}
 	return false, fmt.Errorf("S3 Currently Unreachable")
@@ -964,7 +977,7 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 		Method:     req.method,
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Close:      true,
+		Close:      false,
 		Header:     req.headers,
 	}
 
@@ -980,7 +993,10 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 		s3.client = &http.Client{
 			Transport: &http.Transport{
 				Dial: func(netw, addr string) (c net.Conn, err error) {
-					c, err = net.DialTimeout(netw, addr, s3.ConnectTimeout)
+					c, err = (&net.Dialer{
+						Timeout:   s3.ConnectTimeout,
+						KeepAlive: 30 * time.Second,
+					}).Dial(netw, addr)
 					if err != nil {
 						return
 					}


### PR DESCRIPTION
S3 client does not have keep alive set. When doing many calls to the same endpoint it spends most of the time working on the https handshake. 