### PR TITLE
Adds ability to remove elb tags

### DIFF
--- a/elb/elb.go
+++ b/elb/elb.go
@@ -303,6 +303,30 @@ func (elb *ELB) AddTags(elbName string, tags map[string]string) (*SimpleResp, er
 	return response, nil
 }
 
+// Remove tags from the named ELB
+//
+// Note that AWS only accepts one ELB name at a time (even though it is sent as a list)
+//
+// see http://goo.gl/ochFqo for more details
+
+func (elb *ELB) RemoveTags(elbName string, tagKeys []string) (*SimpleResp, error) {
+	response := &SimpleResp{}
+	params := make(map[string]string)
+
+	params["Action"] = "RemoveTags"
+	params["LoadBalancerNames.member.1"] = elbName
+
+	for i, tagKey := range tagKeys {
+		params[fmt.Sprintf("Tags.member.%d.Key", i+1)] = tagKey
+	}
+
+	if err := elb.query(params, response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 func (elb *ELB) query(params map[string]string, resp interface{}) error {
 	params["Version"] = "2012-06-01"
 	params["Timestamp"] = time.Now().In(time.UTC).Format(time.RFC3339)

--- a/elb/response_test.go
+++ b/elb/response_test.go
@@ -213,7 +213,7 @@ var AddTagsSuccessResponse = `
 </AddTagsResponse>
 `
 
-var AddTagsBadRequest = `
+var TagsBadRequest = `
 <ErrorResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
     <Error>
         <Type>Sender</Type>
@@ -222,4 +222,13 @@ var AddTagsBadRequest = `
     </Error>
     <RequestId>terrible-request-id</RequestId>
 </ErrorResponse>
+`
+
+var RemoveTagsSuccessResponse = `
+<RemoveTagsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+  <RemoveTagsResult/>
+  <ResponseMetadata>
+    <RequestId>83c88b9d-12b7-11e3-8b82-87b12DIFFEXAMPLE</RequestId>
+  </ResponseMetadata>
+</RemoveTagsResponse>
 `


### PR DESCRIPTION
Also switched around my failure test response to be shared between both tests (it's exactly the same since it uses a common AWS failure).