### PR TITLE
Add InitMultiHeader.

### DIFF
--- a/s3/multi.go
+++ b/s3/multi.go
@@ -103,14 +103,21 @@ func (b *Bucket) Multi(key, contType string, perm ACL) (*Multi, error) {
 
 // InitMulti initializes a new multipart upload at the provided
 // key inside b and returns a value for manipulating it.
+// Instead of Content-Type string, pass in custom headers to override defaults.
 //
 // See http://goo.gl/XP8kL for details.
-func (b *Bucket) InitMulti(key string, contType string, perm ACL) (*Multi, error) {
+func (b *Bucket) InitMultiHeader(key string, customHeaders map[string][]string, perm ACL) (*Multi, error) {
 	headers := map[string][]string{
-		"Content-Type":   {contType},
+		"Content-Type":   {"application/text"},
 		"Content-Length": {"0"},
 		"x-amz-acl":      {string(perm)},
 	}
+
+	// Override with custom headers
+	for key, value := range customHeaders {
+		headers[key] = value
+	}
+
 	params := map[string][]string{
 		"uploads": {""},
 	}
@@ -135,6 +142,17 @@ func (b *Bucket) InitMulti(key string, contType string, perm ACL) (*Multi, error
 		return nil, err
 	}
 	return &Multi{Bucket: b, Key: key, UploadId: resp.UploadId}, nil
+}
+
+// InitMulti initializes a new multipart upload at the provided
+// key inside b and returns a value for manipulating it.
+//
+// See http://goo.gl/XP8kL for details.
+func (b *Bucket) InitMulti(key string, contType string, perm ACL) (*Multi, error) {
+	headers := map[string][]string{
+		"Content-Type": {contType},
+	}
+	return b.InitMultiHeader(key, headers, perm)
 }
 
 // PutPart sends part n of the multipart upload, reading all the content from r.


### PR DESCRIPTION
Added the function `InitMultiHeader` (named like `PutHeader` and `PutReaderHeader`) that takes in a `customHeaders` map rather than a contentType map to allow the user to add custom headers to a multipart file upload.