### PR TITLE
Allow for queries to scan index in descending order 

### DIFF
--- a/dynamodb/query.go
+++ b/dynamodb/query.go
@@ -16,7 +16,6 @@ func (t *Table) QueryOnIndex(attributeComparisons []AttributeComparison, indexNa
 	q := NewQuery(t)
 	q.AddKeyConditions(attributeComparisons)
 	q.AddIndex(indexName)
-	q.ScanIndexDescending()
 	return runQuery(q, t)
 }
 
@@ -24,6 +23,7 @@ func (t *Table) QueryOnIndexDescending(attributeComparisons []AttributeCompariso
 	q := NewQuery(t)
 	q.AddKeyConditions(attributeComparisons)
 	q.AddIndex(indexName)
+	q.ScanIndexDescending()
 	return runQuery(q, t)
 }
 

--- a/dynamodb/query.go
+++ b/dynamodb/query.go
@@ -16,6 +16,14 @@ func (t *Table) QueryOnIndex(attributeComparisons []AttributeComparison, indexNa
 	q := NewQuery(t)
 	q.AddKeyConditions(attributeComparisons)
 	q.AddIndex(indexName)
+	q.ScanIndexDescending()
+	return runQuery(q, t)
+}
+
+func (t *Table) QueryOnIndexDescending(attributeComparisons []AttributeComparison, indexName string) ([]map[string]*Attribute, error) {
+	q := NewQuery(t)
+	q.AddKeyConditions(attributeComparisons)
+	q.AddIndex(indexName)
 	return runQuery(q, t)
 }
 

--- a/dynamodb/query.go
+++ b/dynamodb/query.go
@@ -34,6 +34,23 @@ func (t *Table) LimitedQueryOnIndex(attributeComparisons []AttributeComparison, 
 	return runQuery(q, t)
 }
 
+func (t *Table) LimitedQueryDescending(attributeComparisons []AttributeComparison, limit int64) ([]map[string]*Attribute, error) {
+	q := NewQuery(t)
+	q.AddKeyConditions(attributeComparisons)
+	q.AddLimit(limit)
+	q.ScanIndexDescending()
+	return runQuery(q, t)
+}
+
+func (t *Table) LimitedQueryOnIndexDescending(attributeComparisons []AttributeComparison, indexName string, limit int64) ([]map[string]*Attribute, error) {
+	q := NewQuery(t)
+	q.AddKeyConditions(attributeComparisons)
+	q.AddIndex(indexName)
+	q.AddLimit(limit)
+	q.ScanIndexDescending()
+	return runQuery(q, t)
+}
+
 func (t *Table) CountQuery(attributeComparisons []AttributeComparison) (int64, error) {
 	q := NewQuery(t)
 	q.AddKeyConditions(attributeComparisons)

--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -182,6 +182,10 @@ func (q *Query) AddIndex(value string) {
 	q.buffer["IndexName"] = value
 }
 
+func (q *Query) ScanIndexDescending() {
+	q.buffer["ScanIndexForward"] = "false"
+}
+
 /*
    "ScanFilter":{
        "AttributeName1":{"AttributeValueList":[{"S":"AttributeValue"}],"ComparisonOperator":"EQ"}


### PR DESCRIPTION
From what I could tell, there's no way to query an index in descending order (using the `scanIndexForward`) parameter. I could be wrong about this however - if there is a way, please let me know. 

In this PR I've added the functionality to query_builder.go and query.go - It results in a lot of additional functions. In general I don't like this approach, as it leads to a lot of duplicate code as a way of exposing non-attributeComparison parameters. If further parameters are to be added, I'd recommended exposing the buildQuery function to allow users to build their own queries and run them themselves.  