### PR TITLE
Adding support to update throughput on a DynamoDB table

### DIFF
--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -167,6 +167,27 @@ func (q *Query) AddDeleteRequestTable(description TableDescriptionT) {
 	b["TableName"] = description.TableName
 }
 
+func (q *Query) AddUpdateRequestTable(description TableDescriptionT) {
+	b := q.buffer
+
+	attDefs := []interface{}{}
+	for _, attr := range description.AttributeDefinitions {
+		attDefs = append(attDefs, msi{
+			"AttributeName": attr.Name,
+			"AttributeType": attr.Type,
+		})
+	}
+	if len(attDefs) > 0 {
+		b["AttributeDefinitions"] = attDefs
+	}
+	b["TableName"] = description.TableName
+	b["ProvisionedThroughput"] = msi{
+		"ReadCapacityUnits":  int(description.ProvisionedThroughput.ReadCapacityUnits),
+		"WriteCapacityUnits": int(description.ProvisionedThroughput.WriteCapacityUnits),
+	}
+
+}
+
 func (q *Query) AddKeyConditions(comparisons []AttributeComparison) {
 	q.buffer["KeyConditions"] = buildComparisons(comparisons)
 }

--- a/dynamodb/table.go
+++ b/dynamodb/table.go
@@ -208,6 +208,25 @@ func (s *Server) DescribeTable(name string) (*TableDescriptionT, error) {
 	return &r.Table, nil
 }
 
+func (s *Server) UpdateTable(tableDescription TableDescriptionT) (string, error) {
+	query := NewEmptyQuery()
+	query.AddUpdateRequestTable(tableDescription)
+
+	jsonResponse, err := s.queryServer(target("UpdateTable"), query)
+
+	if err != nil {
+		return "unknown", err
+	}
+
+	json, err := simplejson.NewJson(jsonResponse)
+
+	if err != nil {
+		return "unknown", err
+	}
+
+	return json.Get("TableDescription").Get("TableStatus").MustString(), nil
+}
+
 func keyParam(k *PrimaryKey, hashKey string, rangeKey string) string {
 	value := fmt.Sprintf("{\"HashKeyElement\":{%s}", keyValue(k.KeyAttribute.Type, hashKey))
 


### PR DESCRIPTION
At the moment this change allows you to modify the throughput on a DynamoDB table. More work is required to support adding/deleting/updating global-secondary-indexes.