### PR TITLE
Fix bug in s3Test Server

### DIFF
--- a/s3/s3test/server.go
+++ b/s3/s3test/server.go
@@ -594,6 +594,10 @@ func (objr objectResource) put(a *action) interface{} {
 	obj.checksum = gotHash
 	obj.mtime = time.Now()
 	objr.bucket.objects[objr.name] = obj
+
+	h := a.w.Header()
+	h.Set("ETag", fmt.Sprintf(`"%s"`, hex.EncodeToString(obj.checksum)))
+
 	return nil
 }
 


### PR DESCRIPTION
The AWS CLI expects the ETag header to be set to the MD5 of the uploaded file. The code currently does not do that for object PUT requests, as a result of which the AWS CLI fails when uploading to the test server.

This fix adds the ETag header (within double quotes) to the PUT response from the test server.  The double-quotes are necessary as the AWS CLI strips them out before performing an MD5 comparison of the uploaded file.
