### PR TITLE
S3 doesn't retry upon getting tls-handshake timeout

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -1104,7 +1104,11 @@ func shouldRetry(err error) bool {
 		case "InternalError", "NoSuchUpload", "NoSuchBucket":
 			return true
 		}
+	// let's handle tls handshake timeout issues and similar temporary errors
+	case net.Error:
+		return e.Temporary()
 	}
+
 	return false
 }
 


### PR DESCRIPTION
Summary:
In some environments, the TLS handshake can fail, but the Go AWS client
doesn't retry. This change fixes the issue by levarging the net.Error()
interface since tlsHandshakeTimeoutError is not exposed. It fixes any
potential errors that are temporary in nature too.