### PR TITLE
S3 retries on RequestTimeout

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -1101,7 +1101,7 @@ func shouldRetry(err error) bool {
 		}
 	case *Error:
 		switch e.Code {
-		case "InternalError", "NoSuchUpload", "NoSuchBucket":
+		case "InternalError", "NoSuchUpload", "NoSuchBucket", "RequestTimeout":
 			return true
 		}
 	// let's handle tls handshake timeout issues and similar temporary errors


### PR DESCRIPTION
When running with a very high request rate, I've had problems with a rare few S3 requests failing with the RequestTimeout error code. No idea if this is on my end or S3's -- probably a connection not getting properly closed somewhere -- but it's definitely a temporary network error that would be appropriate to auto-retry.