### PR TITLE
Change all bools in 'ModifyInstanceAttribute' to strings

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -1064,14 +1064,14 @@ func (ec2 *EC2) RebootInstances(ids ...string) (resp *SimpleResp, err error) {
 type ModifyInstance struct {
 	InstanceType          string
 	BlockDevices          []BlockDeviceMapping
-	DisableAPITermination bool
-	EbsOptimized          bool
+	DisableAPITermination string
+	EbsOptimized          string
 	SecurityGroups        []SecurityGroup
 	ShutdownBehavior      string
 	KernelId              string
 	RamdiskId             string
-	SourceDestCheck       bool
-	SriovNetSupport       bool
+	SourceDestCheck       string
+	SriovNetSupport       string
 	UserData              []byte
 }
 
@@ -1097,12 +1097,12 @@ func (ec2 *EC2) ModifyInstance(instId string, options *ModifyInstance) (resp *Mo
 		params["InstanceType.Value"] = options.InstanceType
 	}
 
-	if options.DisableAPITermination {
-		params["DisableApiTermination.Value"] = "true"
+	if options.DisableAPITermination != "" {
+		params["DisableApiTermination.Value"] = options.DisableAPITermination
 	}
 
-	if options.EbsOptimized {
-		params["EbsOptimized"] = "true"
+	if options.EbsOptimized != "" {
+		params["EbsOptimized"] = options.EbsOptimized
 	}
 
 	if options.ShutdownBehavior != "" {
@@ -1117,12 +1117,12 @@ func (ec2 *EC2) ModifyInstance(instId string, options *ModifyInstance) (resp *Mo
 		params["Ramdisk.Value"] = options.RamdiskId
 	}
 
-	if options.SourceDestCheck {
-		params["SourceDestCheck.Value"] = "true"
+	if options.SourceDestCheck != "" {
+		params["SourceDestCheck.Value"] = options.SourceDestCheck
 	}
 
-	if options.SriovNetSupport {
-		params["SriovNetSupport.Value"] = "simple"
+	if options.SriovNetSupport != "" {
+		params["SriovNetSupport.Value"] = options.SriovNetSupport
 	}
 
 	if options.UserData != nil {

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -1224,14 +1224,14 @@ func (s *S) TestModifyInstance(c *C) {
 
 	options := ec2.ModifyInstance{
 		InstanceType:          "m1.small",
-		DisableAPITermination: true,
-		EbsOptimized:          true,
+		DisableAPITermination: "true",
+		EbsOptimized:          "true",
 		SecurityGroups:        []ec2.SecurityGroup{{Id: "g1"}, {Id: "g2"}},
 		ShutdownBehavior:      "terminate",
 		KernelId:              "kernel-id",
 		RamdiskId:             "ramdisk-id",
-		SourceDestCheck:       true,
-		SriovNetSupport:       true,
+		SourceDestCheck:       "true",
+		SriovNetSupport:       "simple",
 		UserData:              []byte("1234"),
 		BlockDevices: []ec2.BlockDeviceMapping{
 			{DeviceName: "/dev/sda1", SnapshotId: "snap-a08912c9", DeleteOnTermination: true},


### PR DESCRIPTION
API reference for 'ModifyInstanceAttribute' states:
*You can specify only one attribute at a time.*

Honoring this requirement in a sensible manner is currently impossible, e.g. Source/Destination check can be enabled, but not disabled.

After this change it will be the user's responsibility to set the string to `true` or `false` if he chooses to alter a boolean parameter, or leave it as en empty string if he wants to omit it.