### PR TITLE
Fix complete upload bug in s3 multipart upload.

### DIFF
--- a/s3/multi.go
+++ b/s3/multi.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"io"
 	"sort"
 	"strconv"
@@ -339,8 +340,20 @@ func (p completeParts) Len() int           { return len(p) }
 func (p completeParts) Less(i, j int) bool { return p[i].PartNumber < p[j].PartNumber }
 func (p completeParts) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
+type completeResponse struct {
+	// The element name: should be either CompleteMultipartUploadResult or Error.
+	XMLName xml.Name
+	// If the element was error, then it should have Code and Message fields.
+	Code    string
+	Message string
+}
+
 // Complete assembles the given previously uploaded parts into the
 // final object. This operation may take several minutes.
+//
+// The complete call to AMZ may still fail after returning HTTP 200,
+// so even though it's unusued, the body of the reply must be demarshalled
+// and checked to see whether or not the complete succeeded.
 //
 // See http://goo.gl/2Z7Tw for details.
 func (m *Multi) Complete(parts []Part) error {
@@ -370,7 +383,11 @@ func (m *Multi) Complete(parts []Part) error {
 			},
 		}
 
-		err := m.Bucket.S3.query(req, nil)
+		resp := &completeResponse{}
+		err := m.Bucket.S3.query(req, resp)
+		if err == nil && resp.XMLName.Local == "Error" {
+			err = errors.New(fmt.Sprintf("S3 error Code %s message '%s'", resp.Code, resp.Message))
+		}
 		if shouldRetry(err) && attempt.HasNext() {
 			continue
 		}

--- a/s3/multi_test.go
+++ b/s3/multi_test.go
@@ -300,7 +300,9 @@ func (s *S) TestMultiComplete(c *C) {
 	c.Assert(err, IsNil)
 
 	err = multi.Complete([]s3.Part{{2, `"ETag2"`, 32}, {1, `"ETag1"`, 64}})
-	c.Assert(err, IsNil)
+	// returns InternalErrorDump in the payload, which should manifest as
+	// an error.
+	c.Assert(err, NotNil)
 
 	testServer.WaitRequest()
 	req := testServer.WaitRequest()


### PR DESCRIPTION
The multipart upload operation of s3 works by a sequence of calls.
The last one is multipart.Complete. The s3 semantics are rather
kludgy: if they can successfully start the process of completing a
multipart upload, they return HTTP 200, and periodically write a space
into the response body to maintain the connection. If the complete operation
fails during processing, that's passed to the client by putting an
Error element into the response body.

The go implementation of the multipart.Complete method wasn't checking
the message body, and was just declaring success when it saw the 200.