### PR TITLE
Add Host field to s3test.Config type for configuring s3test server host

### DIFF
--- a/s3/s3t_test.go
+++ b/s3/s3t_test.go
@@ -39,7 +39,11 @@ type LocalServerSuite struct {
 
 var (
 	// run tests twice, once in us-east-1 mode, once not.
-	_ = Suite(&LocalServerSuite{})
+	_ = Suite(&LocalServerSuite{
+		srv: LocalServer{
+			config: &s3test.Config{},
+		},
+	})
 	_ = Suite(&LocalServerSuite{
 		srv: LocalServer{
 			config: &s3test.Config{

--- a/s3/s3test/server.go
+++ b/s3/s3test/server.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
-	"github.com/goamz/goamz/s3"
 	"io"
 	"io/ioutil"
 	"log"
@@ -20,6 +19,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/goamz/goamz/s3"
 )
 
 const debug = false
@@ -51,6 +52,8 @@ type Config struct {
 	// all other regions.
 	// http://docs.amazonwebservices.com/AmazonS3/latest/API/ErrorResponses.html
 	Send409Conflict bool
+	// Set the host string on which to serve s3test server.
+	Host string
 }
 
 func (c *Config) send409Conflict() bool {
@@ -97,7 +100,11 @@ type resource interface {
 }
 
 func NewServer(config *Config) (*Server, error) {
-	l, err := net.Listen("tcp", "localhost:0")
+	if config.Host == "" {
+		config.Host = "localhost:0"
+	}
+
+	l, err := net.Listen("tcp", config.Host)
 	if err != nil {
 		return nil, fmt.Errorf("cannot listen on localhost: %v", err)
 	}


### PR DESCRIPTION
I don't know if this is of any use to anyone. I quite like this s3test server so I am running one in a docker container and wanted to set the Host myself. Thought this might be of use to others so I thought I would open a PR :)

e.g.
```go
server, err := s3test.New(&s3test.Config{Host: "localhost:54322"})
...
```