### PR TITLE
Use attempt strategy for PutCopy

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -18,7 +18,6 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
-	"github.com/goamz/goamz/aws"
 	"io"
 	"io/ioutil"
 	"log"
@@ -29,6 +28,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/goamz/goamz/aws"
 )
 
 const debug = false
@@ -340,7 +341,7 @@ func (b *Bucket) Put(path string, data []byte, contType string, perm ACL, option
 }
 
 // PutCopy puts a copy of an object given by the key path into bucket b using b.Path as the target key
-func (b *Bucket) PutCopy(path string, perm ACL, options CopyOptions, source string) (*CopyObjectResult, error) {
+func (b *Bucket) PutCopy(path string, perm ACL, options CopyOptions, source string) (result *CopyObjectResult, err error) {
 	headers := map[string][]string{
 		"x-amz-acl":         {string(perm)},
 		"x-amz-copy-source": {source},
@@ -352,12 +353,17 @@ func (b *Bucket) PutCopy(path string, perm ACL, options CopyOptions, source stri
 		path:    path,
 		headers: headers,
 	}
-	resp := &CopyObjectResult{}
-	err := b.S3.query(req, resp)
-	if err != nil {
-		return resp, err
+	result = &CopyObjectResult{}
+	for attempt := b.S3.AttemptStrategy.Start(); attempt.Next(); {
+		err = b.S3.query(req, result)
+		if !shouldRetry(err) {
+			break
+		}
 	}
-	return resp, nil
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 /*


### PR DESCRIPTION
PutCopy often fails with transient errors. This uses the attempt strategy to retry just like List, Head, DelBucket, etc.