### PR TITLE
Avoid closing connections to S3

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -977,7 +977,6 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 		Method:     req.method,
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Close:      true,
 		Header:     req.headers,
 	}
 


### PR DESCRIPTION
An application I'm developing was suffering from very high latency when connecting to S3, because we aren't reusing connections. This PR should fix it.