### PR TITLE
SES API returns 403 when using assumed role credentials from instance profile

### DIFF
--- a/exp/ses/ses.go
+++ b/exp/ses/ses.go
@@ -113,6 +113,10 @@ func (ses *SES) doPost(action string, data url.Values) error {
 
 	req.URL = URL
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	token := ses.auth.Token()
+	if token != "" {
+		req.Header.Set("X-Amz-Security-Token", token)
+	}
 	sign(ses.auth, "POST", req.Header)
 
 	data.Add("AWSAccessKeyId", ses.auth.AccessKey)

--- a/exp/ses/ses.go
+++ b/exp/ses/ses.go
@@ -143,7 +143,7 @@ func (ses *SES) doPost(action string, data url.Values) error {
 }
 
 func buildError(r *http.Response) *SESError {
-	err := SESError{}
-	xml.NewDecoder(r.Body).Decode(&err)
-	return &err
+	rootElem := errorResponse{}
+	xml.NewDecoder(r.Body).Decode(&rootElem)
+	return &rootElem.Error
 }

--- a/exp/ses/ses_types.go
+++ b/exp/ses/ses_types.go
@@ -45,6 +45,10 @@ type SESError struct {
 	RequestId string
 }
 
+type errorResponse struct {
+	Error SESError
+}
+
 func (err *SESError) Error() string {
 	return err.Message
 }


### PR DESCRIPTION
the code was working fine in my dev, but was failing when running on EC2 that had an instance profile with sufficient privileges. I found the token header in another part of the code, so copying it over made things start working on EC2.

also corrected error response parsing so that an empty string is not returned as the error