### PR TITLE
Add ap-northeast-2 Region

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -65,6 +65,7 @@ type Region struct {
 
 var Regions = map[string]Region{
 	APNortheast.Name:  APNortheast,
+	APNortheast2.Name: APNortheast2,
 	APSoutheast.Name:  APSoutheast,
 	APSoutheast2.Name: APSoutheast2,
 	EUCentral.Name:    EUCentral,

--- a/aws/regions.go
+++ b/aws/regions.go
@@ -207,6 +207,29 @@ var APNortheast = Region{
 	"https://streams.dynamodb.ap-northeast-1.amazonaws.com",
 }
 
+var APNortheast2 = Region{
+	"ap-northeast-2",
+	"https://ec2.ap-northeast-2.amazonaws.com",
+	"https://s3-ap-northeast-2.amazonaws.com",
+	"",
+	true,
+	true,
+	"https://sdb.ap-northeast-2.amazonaws.com",
+	"",
+	"https://sns.ap-northeast-2.amazonaws.com",
+	"https://sqs.ap-northeast-2.amazonaws.com",
+	"https://iam.amazonaws.com",
+	"https://elasticloadbalancing.ap-northeast-2.amazonaws.com",
+	"https://dynamodb.ap-northeast-2.amazonaws.com",
+	ServiceInfo{"https://monitoring.ap-northeast-2.amazonaws.com", V2Signature},
+	"https://autoscaling.ap-northeast-2.amazonaws.com",
+	ServiceInfo{"https://rds.ap-northeast-2.amazonaws.com", V2Signature},
+	"https://sts.amazonaws.com",
+	"https://cloudformation.ap-northeast-2.amazonaws.com",
+	"https://ecs.ap-northeast-2.amazonaws.com",
+	"https://streams.dynamodb.ap-northeast-2.amazonaws.com",
+}
+
 var SAEast = Region{
 	"sa-east-1",
 	"https://ec2.sa-east-1.amazonaws.com",

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -59,6 +59,8 @@ func NewFrom(accessKey, secretKey, region string) (*SQS, error) {
 		aws_region = aws.APSoutheast2
 	case "ap.northeast", "ap.northeast.1":
 		aws_region = aws.APNortheast
+	case "ap.northeast.2":
+		aws_region = aws.APNortheast2
 	case "sa.east", "sa.east.1":
 		aws_region = aws.SAEast
 	case "cn.north", "cn.north.1":


### PR DESCRIPTION
Since (perhaps) goamz uses v4 signature in SQS at d9dce97b0a7877b5d866db68d165b0de57534109
I cannot use SQS using a url starting with "https://" (e.g. https://sqs.ap-northeast-2.amazonaws.com/).

goamz does not have a definition of ap-northeast-2 (Seoul) Region, I cannot use  ap-northeast-2 SQS.
