### PR TITLE
Fix s3test Last-Modified time format

### DIFF
--- a/s3/s3test/server.go
+++ b/s3/s3test/server.go
@@ -497,6 +497,8 @@ type objectResource struct {
 	object  *object // may be nil.
 }
 
+const awsTimeFormat = "Mon, 2 Jan 2006 15:04:05 GMT"
+
 // GET on an object gets the contents of the object.
 // http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTObjectGET.html
 func (objr objectResource) get(a *action) interface{} {
@@ -531,7 +533,7 @@ func (objr objectResource) get(a *action) interface{} {
 	// TODO x-amz-request-id
 	h.Set("Content-Length", fmt.Sprint(len(obj.data)))
 	h.Set("ETag", hex.EncodeToString(obj.checksum))
-	h.Set("Last-Modified", obj.mtime.Format(time.RFC1123))
+	h.Set("Last-Modified", obj.mtime.Format(awsTimeFormat))
 	if a.req.Method == "HEAD" {
 		return nil
 	}


### PR DESCRIPTION
See https://github.com/aws/aws-sdk-go/blob/af3026711cd873ccb4e87a7142fa8ca0be8f2aef/private/protocol/rest/build.go#L22

```go
// RFC822 returns an RFC822 formatted timestamp for AWS protocols
const RFC822 = "Mon, 2 Jan 2006 15:04:05 GMT"
```