### PR TITLE
Send nil Body when payload is empty

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -984,6 +984,9 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 	if v, ok := req.headers["Content-Length"]; ok {
 		hreq.ContentLength, _ = strconv.ParseInt(v[0], 10, 64)
 		delete(req.headers, "Content-Length")
+		if hreq.ContentLength == 0 {
+			req.payload = nil
+		}
 	}
 	if req.payload != nil {
 		hreq.Body = ioutil.NopCloser(req.payload)


### PR DESCRIPTION
There's a slight change in the behaviour of the Content-Length header
in tip, notably that sending a non-nil body and Content-Length of 0
results in the client not sending the Content-Length header.

See the following for justification and implmentation:
https://github.com/golang/go/commit/4859f6a416b053d57fcc9d8f43e81e9d218280e9
https://github.com/golang/go/blob/master/src/net/http/request.go#L1281-L1291