### PR TITLE
The response body must be closed even when it is not used

### DIFF
--- a/exp/ses/ses.go
+++ b/exp/ses/ses.go
@@ -134,8 +134,8 @@ func (ses *SES) doPost(action string, data url.Values) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode > 204 {
-		defer resp.Body.Close()
 		return buildError(resp)
 	}
 


### PR DESCRIPTION
The https://golang.org/pkg/net/http/ states :
The client must close the response body when finished with it. 
The problem appears when we receive 200 from SES (success email sending). 
In this case the response body is not closed as it is not used but in order to prevent a memory leak the response body must be closed even when it is not used.
 
I observed it accidentally as when you'll send an email from a new go routine you'll encounter into permanently increasing number of go routines.    

