### PR TITLE
Expose NewResilientTransport with optional http.Transport argument

### DIFF
--- a/aws/sign.go
+++ b/aws/sign.go
@@ -157,7 +157,6 @@ If neither header is defined or we are unable to parse either header as a valid 
 then we will create a new "x-amz-date" header with the current time.
 */
 func (s *V4Signer) requestTime(req *http.Request) time.Time {
-
 	// Get "x-amz-date" header
 	date := req.Header.Get("x-amz-date")
 

--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -263,7 +263,6 @@ func (c *CloudWatch) GetMetricStatistics(req *GetMetricStatisticsRequest) (resul
 // Returned metrics can be used with GetMetricStatistics to obtain statistical data for a given metric.
 
 func (c *CloudWatch) ListMetrics(req *ListMetricsRequest) (result *ListMetricsResponse, err error) {
-
 	// Serialize all the params
 	params := aws.MakeParams("ListMetrics")
 	if req.Namespace != "" {

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -271,7 +271,6 @@ type RunInstancesResp struct {
 //
 // See http://goo.gl/OCH8a for more details.
 type Instance struct {
-
 	// General instance information
 	InstanceId         string              `xml:"instanceId"`                 // The ID of the instance launched
 	InstanceType       string              `xml:"instanceType"`               // The instance type eg. m1.small | m1.medium | m1.large etc

--- a/s3/s3i_test.go
+++ b/s3/s3i_test.go
@@ -481,7 +481,7 @@ func (s *ClientTests) TestMultiComplete(c *C) {
 	c.Assert(len(data), Equals, len(data1)+len(data2))
 	for i := range data1 {
 		if data[i] != data1[i] {
-			c.Fatalf("uploaded object at byte %d: want %d, got %d", data1[i], data[i])
+			c.Fatalf("uploaded object at byte %d: want %d, got %d", i, data1[i], data[i])
 		}
 	}
 	c.Assert(string(data[len(data1):]), Equals, string(data2))


### PR DESCRIPTION
Hello all,

this PR adds `aws.NewResilientTransport` with an optional `http.Transport` argument, which provides more flexibility when creating an aws client. It fixes a `TODO` added in [f39dec7f](https://github.com/goamz/goamz/commit/f39dec7f0947912d3d89fed1caf8f60ea01d2698#diff-03cbd579aea1ff4a83f9f18400518b7bR48).